### PR TITLE
Improve the docs about syncing custom files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,9 +518,9 @@ We can [with your help](doc#get-official-support-for-an-application) ;)
 ## Personalization & configuration
 
 Have an application that shouldn't be generally supported but that you use?
-Or a cool file you want to sync?
+Or some personal files you want to sync, e.g. various config files in a `~/.config/`
+directory or your personal `~/.gitignore`?
 
-- Use a `~/.mackup.cfg` to [sync a single file](doc#configuration) (e.g. `~/.gitignore`)
 - Create a `~/.mackup` directory to [sync an application or any file or directory](doc#add-support-for-an-application-or-any-file-or-directory)
 
 ## Why did you do this

--- a/doc/README.md
+++ b/doc/README.md
@@ -9,17 +9,6 @@ To configure Mackup, create a file named ´.mackup.cfg´ in your home directory.
 vi ~/.mackup.cfg
 ```
 
-Add personal files to sync by including the `configuration_files` header, e.g.
-
-```ini
-[configuration_files]
-.gitignore_global
-.config/your-custom-file
-```
-
-Note that Mackup assumes the file paths listed here are relative to your home
-directory.
-
 ## Storage
 
 ### Dropbox
@@ -162,11 +151,11 @@ You can customize the Mackup engine and add support for unsupported
 applications or just custom files and directories you'd like to sync.
 
 Let's say that you'd like to add support for Nethack (config file:
-`.nethackrc`) and for the `bin` and `.hidden` directories you keep in your
-home.
+`.nethackrc`), for the `bin` and `.hidden` directories and for the
+`.gitignore` file you keep in your home.
 
 In your home, create a `.mackup` directory and add a config file for the
-application you'd like to support.
+application you'd like to support:
 
 ```bash
 mkdir ~/.mackup
@@ -174,7 +163,7 @@ touch ~/.mackup/nethack.cfg
 touch ~/.mackup/my-files.cfg
 ```
 
-Edit those files
+Edit those files:
 
 ```bash
 $ cat ~/.mackup/nethack.cfg
@@ -193,9 +182,13 @@ name = My personal synced files and dirs
 [configuration_files]
 bin
 .hidden
+.gitignore
 ```
 
-You can run mackup to see if they are listed
+Note that Mackup assumes the file paths listed here are relative to your home
+directory.
+
+You can run mackup to see if they are listed:
 
 ```bash
 $ mackup list


### PR DESCRIPTION
As reported in https://github.com/lra/mackup/issues/869, the `[configuration_files]` section of the `.mackup.cfg` is not working as advertised in the `Configuration` chapter of the docs.

The users should be pointed to the section where the syncing of custom apps (and individual files) is explained until #869 has been fixed.